### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 on: [push, pull_request]
 
 name: Test
+permissions:
+  contents: read
 
 jobs:
   code-quality:


### PR DESCRIPTION
Potential fix for [https://github.com/confy-security/confy-addons/security/code-scanning/3](https://github.com/confy-security/confy-addons/security/code-scanning/3)

The best way to fix this problem is to add a `permissions:` block at the root of `.github/workflows/test.yml`. This block will apply to all jobs in the workflow unless they override it. Since the jobs shown need only to read the repository contents (for code checkout and artifact uploads), setting `permissions: contents: read` suffices per GitHub’s least privilege guidelines.  
- Place the `permissions:` block after the `name:` key and before `jobs:` in `.github/workflows/test.yml`.
- No imports, special definitions, or further code changes are needed.
- The fix will not affect existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
